### PR TITLE
Terminal pixel grid fix

### DIFF
--- a/src/apps/scalable/terminal.svg
+++ b/src/apps/scalable/terminal.svg
@@ -1,56 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="64" height="64" version="1.1" viewBox="0 0 16.933 16.933" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
- <metadata>
-  <rdf:RDF>
-   <cc:Work rdf:about="">
-    <dc:format>image/svg+xml</dc:format>
-    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:title/>
-   </cc:Work>
-  </rdf:RDF>
- </metadata>
- <defs>
-  <linearGradient id="linearGradient2556" x1="-305" x2="-240" y1="38" y2="38" gradientTransform="matrix(.22387 0 0 .22387 54.931 -4.8242)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#505050" offset="0"/>
-   <stop stop-color="#323232" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient2652" x1="-261.67" x2="-240" y1="13" y2="13" gradientTransform="matrix(.22387 0 0 .22387 54.931 -4.8242)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#636363" offset="0"/>
-   <stop stop-color="#646464" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient2644" x1="-283.33" x2="-261.67" y1="13" y2="13" gradientTransform="matrix(.22387 0 0 .22387 54.931 -4.8242)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#989898" offset="0"/>
-   <stop stop-color="#999" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient2636" x1="-305" x2="-283.33" y1="13" y2="13" gradientTransform="matrix(.22387 0 0 .22387 54.931 -4.8242)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#cecece" offset="0"/>
-   <stop stop-color="#d0d0d0" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient2580" x1="-183.26" x2="-133.33" y1="-122.79" y2="-134.57" gradientTransform="matrix(.080469 0 0 .080469 2.3077 6.7492)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#a9a9a9" offset="0"/>
-   <stop stop-color="#8c8c8c" offset="1"/>
-  </linearGradient>
-  <filter id="filter2594" x="-.084" y="-.084" width="1.168" height="1.168" color-interpolation-filters="sRGB">
-   <feGaussianBlur stdDeviation="0.43959997"/>
-  </filter>
-  <linearGradient id="linearGradient2574" x1="-183.26" x2="-133.33" y1="-122.79" y2="-134.57" gradientTransform="matrix(.08047 0 0 .08047 7.5104 1.5352)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient2586"/>
-  <linearGradient id="linearGradient2586" x1="-183.26" x2="-133.33" y1="-122.79" y2="-134.57" gradientTransform="matrix(.25137 0 0 .25137 -7.3652 -24.336)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#e5e5e5" offset="0"/>
-   <stop stop-color="#cecece" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient2608" x1="-183.26" x2="-133.33" y1="-122.79" y2="-134.57" gradientTransform="matrix(.08047 0 0 .08047 10.094 4.6601)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient2586"/>
- </defs>
- <g transform="matrix(1.0909 0 0 1.0909 15.093 5.4256)">
-  <g stroke-width=".22387">
-   <path d="m1.2017-1.0184h-14.552v8.7311c0 0.37208 0.29954 0.67162 0.67162 0.67162h13.209c0.37208 0 0.67162-0.29954 0.67162-0.67162z" fill="url(#linearGradient2556)"/>
-   <path d="m-3.6497-2.8093v1.791h4.8504v-1.1194c0-0.37208-0.29954-0.67162-0.67162-0.67162z" fill="url(#linearGradient2652)"/>
-   <path d="m-8.4988-2.8093v1.791h4.8509v-1.791z" fill="url(#linearGradient2644)"/>
-   <path d="m-13.35-2.1377v1.1194h4.8504v-1.791h-4.1788c-0.37208 0-0.67162 0.29954-0.67162 0.67162z" fill="url(#linearGradient2636)"/>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="64" height="64" viewBox="0 0 64 64" version="1.1">
+<defs>
+<linearGradient id="linear0" gradientUnits="userSpaceOnUse" x1="-306.171" y1="15.2498" x2="-273.6694" y2="15.2498" gradientTransform="matrix(1.8462,0,0,-1.8462,567.2244,64.1528)">
+<stop offset="0" style="stop-color:rgb(31.372549%,31.372549%,31.372549%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(19.607843%,19.607843%,19.607843%);stop-opacity:1;"/>
+</linearGradient>
+<linearGradient id="linear1" gradientUnits="userSpaceOnUse" x1="-284.5038" y1="28.2501" x2="-273.6702" y2="28.2501" gradientTransform="matrix(1.8462,0,0,-1.8462,567.2244,64.1528)">
+<stop offset="0" style="stop-color:rgb(38.823529%,38.823529%,38.823529%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(39.215686%,39.215686%,39.215686%);stop-opacity:1;"/>
+</linearGradient>
+<linearGradient id="linear2" gradientUnits="userSpaceOnUse" x1="-295.3374" y1="28.2501" x2="-284.5038" y2="28.2501" gradientTransform="matrix(1.8462,0,0,-1.8462,567.2244,64.1528)">
+<stop offset="0" style="stop-color:rgb(59.607843%,59.607843%,59.607843%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(60%,60%,60%);stop-opacity:1;"/>
+</linearGradient>
+<linearGradient id="linear3" gradientUnits="userSpaceOnUse" x1="-306.171" y1="28.2501" x2="-295.3374" y2="28.2501" gradientTransform="matrix(1.8462,0,0,-1.8462,567.2244,64.1528)">
+<stop offset="0" style="stop-color:rgb(80.784314%,80.784314%,80.784314%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(81.568627%,81.568627%,81.568627%);stop-opacity:1;"/>
+</linearGradient>
+<linearGradient id="linear4" gradientUnits="userSpaceOnUse" x1="-142.9862" y1="223.0275" x2="-116.9567" y2="229.1687" gradientTransform="matrix(0.4692,-0.4692,-0.4692,-0.4692,183.9172,84.8652)">
+<stop offset="0" style="stop-color:rgb(66.27451%,66.27451%,66.27451%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(54.901961%,54.901961%,54.901961%);stop-opacity:1;"/>
+</linearGradient>
+<filter id="alpha" filterUnits="objectBoundingBox" x="0%" y="0%" width="100%" height="100%">
+  <feColorMatrix type="matrix" in="SourceGraphic" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"/>
+</filter>
+<image id="image9" width="64" height="64" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAABmJLR0QA/wD/AP+gvaeTAAAAhklEQVR4nO3XsQ3CUAwE0HxEZqCkQYI262UEFmAIJssMiRRG+IWJrsh7tWWfrvMwAAAAAABwHq03sK/TXD/z2Nr4fdf3/N+1O9Ge9/qZ21bfcYxLOkCaAtIB0hSQDpCmgHSANAWkA6QpIB0gTQHpAGmnL6D/Du+fpX7mtdZ3AAAAAAAAUPID5mAKIhibwwUAAAAASUVORK5CYII="/>
+<mask id="mask0">
+  <g filter="url(#alpha)">
+<use xlink:href="#image9"/>
   </g>
-  <rect transform="rotate(-45)" x="-12.577" y="-4.3857" width="4.426" height="1.4485" ry=".16094" fill="url(#linearGradient2580)" stroke-width=".080469"/>
-  <rect transform="matrix(.22636 .22636 .22636 -.22636 13.58 6.9821)" x="-68.454" y="-44.561" width="13.826" height="4.5247" ry=".50275" filter="url(#filter2594)" opacity=".6" stroke-width=".25137"/>
-  <rect transform="matrix(.70711 .70711 .70711 -.70711 0 0)" x="-7.3741" y="-9.5996" width="4.426" height="1.4485" ry=".16094" fill="url(#linearGradient2574)" stroke-width=".08047"/>
-  <rect transform="matrix(.32012 0 0 -.32012 17.123 -7.7903)" x="-68.454" y="-44.561" width="13.826" height="4.5247" ry=".50275" filter="url(#filter2594)" opacity=".6" stroke-width=".25137"/>
-  <rect transform="scale(1,-1)" x="-4.791" y="-6.4744" width="4.4259" height="1.4484" ry=".16094" fill="url(#linearGradient2608)" stroke-width=".08047"/>
- </g>
+</mask>
+<clipPath id="clip1">
+  <rect x="0" y="0" width="64" height="64"/>
+</clipPath>
+<g id="surface8" clip-path="url(#clip1)">
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(0%,0%,0%);fill-opacity:1;" d="M 8.210938 26.539062 L 21.179688 38.84375 C 21.46875 39.109375 21.90625 39.109375 22.195312 38.84375 L 25.757812 35.46875 C 25.890625 35.34375 25.96875 35.164062 25.96875 34.984375 C 25.96875 34.804688 25.890625 34.625 25.757812 34.5 L 12.789062 22.203125 C 12.5 21.9375 12.054688 21.9375 11.773438 22.203125 L 8.210938 25.578125 C 8.078125 25.703125 8 25.875 8 26.0625 C 8 26.242188 8.078125 26.414062 8.210938 26.539062 Z M 8.210938 26.539062 "/>
+</g>
+<linearGradient id="linear5" gradientUnits="userSpaceOnUse" x1="-224.7546" y1="141.1896" x2="-198.7251" y2="147.3308" gradientTransform="matrix(0.469236,0.469236,-0.469236,0.469236,183.8518,61.9014)">
+<stop offset="0" style="stop-color:rgb(89.803922%,89.803922%,89.803922%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(80.784314%,80.784314%,80.784314%);stop-opacity:1;"/>
+</linearGradient>
+<image id="image17" width="64" height="64" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAABmJLR0QA/wD/AP+gvaeTAAAAUUlEQVR4nO3QwQmAMBAEwJykSDuwJjuwSCFWkLxCDsPM9+B22VIAAAAAAAAAAAAA2FNkF+hp73nP+BP1uUb3Y0bInxkgu0A2A2QXAAAAAFjtA7p+BAwBvxIEAAAAAElFTkSuQmCC"/>
+<mask id="mask1">
+  <g filter="url(#alpha)">
+<use xlink:href="#image17"/>
+  </g>
+</mask>
+<clipPath id="clip2">
+  <rect x="0" y="0" width="64" height="64"/>
+</clipPath>
+<g id="surface16" clip-path="url(#clip2)">
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(0%,0%,0%);fill-opacity:1;" d="M 38.65625 48 L 55.34375 48 C 55.523438 48 55.6875 47.929688 55.8125 47.804688 C 55.9375 47.679688 56 47.507812 56 47.335938 L 56 42.664062 C 56 42.492188 55.9375 42.320312 55.8125 42.195312 C 55.6875 42.070312 55.523438 42 55.34375 42 L 38.65625 42 C 38.476562 42 38.3125 42.070312 38.1875 42.195312 C 38.0625 42.320312 38 42.492188 38 42.664062 L 38 47.335938 C 38 47.507812 38.0625 47.679688 38.1875 47.804688 C 38.3125 47.929688 38.476562 48 38.65625 48 Z M 38.65625 48 "/>
+</g>
+<linearGradient id="linear6" gradientUnits="userSpaceOnUse" x1="-241.3418" y1="90.8886" x2="-216.6895" y2="96.7048" gradientTransform="matrix(0.6636,0,0,0.6636,198.666,-17.3138)">
+<stop offset="0" style="stop-color:rgb(89.803922%,89.803922%,89.803922%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(80.784314%,80.784314%,80.784314%);stop-opacity:1;"/>
+</linearGradient>
+</defs>
+<g id="surface1">
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear0);" d="M 62 16 L 2 16 L 2 53.140625 C 1.984375 53.890625 2.273438 54.609375 2.789062 55.148438 C 3.3125 55.679688 4.023438 55.992188 4.765625 56 L 59.234375 56 C 59.976562 55.992188 60.6875 55.679688 61.210938 55.148438 C 61.726562 54.609375 62.015625 53.890625 62 53.140625 Z M 62 16 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear1);" d="M 42 8 L 42 16 L 62 16 L 62 11 C 62.03125 10.234375 61.757812 9.492188 61.234375 8.929688 C 60.71875 8.367188 59.992188 8.03125 59.234375 8 Z M 42 8 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear2);" d="M 22 8 L 22 16 L 42 16 L 42 8 Z M 22 8 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear3);" d="M 2 11 L 2 16 L 22 16 L 22 8 L 4.765625 8 C 4.007812 8.03125 3.28125 8.367188 2.765625 8.929688 C 2.242188 9.492188 1.96875 10.234375 2 11 Z M 2 11 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear4);" d="M 8.242188 43.460938 L 21.210938 31.15625 C 21.5 30.890625 21.945312 30.890625 22.226562 31.15625 L 25.789062 34.53125 C 25.921875 34.65625 26 34.835938 26 35.015625 C 26 35.203125 25.921875 35.375 25.789062 35.5 L 12.820312 47.796875 C 12.539062 48.0625 12.09375 48.0625 11.804688 47.796875 L 8.242188 44.421875 C 8.109375 44.296875 8.03125 44.125 8.03125 43.9375 C 8.03125 43.757812 8.109375 43.585938 8.242188 43.460938 Z M 8.242188 43.460938 "/>
+<use xlink:href="#surface8" mask="url(#mask0)"/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear5);" d="M 8.210938 26.539062 L 21.179688 38.84375 C 21.460938 39.109375 21.90625 39.109375 22.195312 38.84375 L 25.757812 35.46875 C 25.890625 35.34375 25.96875 35.164062 25.96875 34.984375 C 25.96875 34.796875 25.890625 34.625 25.757812 34.5 L 12.789062 22.203125 C 12.5 21.9375 12.054688 21.9375 11.773438 22.203125 L 8.210938 25.578125 C 8.078125 25.703125 8 25.875 8 26.0625 C 8 26.242188 8.078125 26.414062 8.210938 26.539062 Z M 8.210938 26.539062 "/>
+<use xlink:href="#surface16" mask="url(#mask1)"/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear6);" d="M 38.65625 48 L 55.34375 48 C 55.523438 48 55.6875 47.929688 55.8125 47.804688 C 55.9375 47.679688 56 47.507812 56 47.335938 L 56 42.664062 C 56 42.492188 55.9375 42.320312 55.8125 42.195312 C 55.6875 42.070312 55.523438 42 55.34375 42 L 38.65625 42 C 38.476562 42 38.3125 42.070312 38.1875 42.195312 C 38.0625 42.320312 38 42.492188 38 42.664062 L 38 47.335938 C 38 47.507812 38.0625 47.679688 38.1875 47.804688 C 38.3125 47.929688 38.476562 48 38.65625 48 Z M 38.65625 48 "/>
+</g>
 </svg>

--- a/src/apps/scalable/xterm-color.svg
+++ b/src/apps/scalable/xterm-color.svg
@@ -1,56 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="64" height="64" version="1.1" viewBox="0 0 16.933 16.933" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
- <metadata>
-  <rdf:RDF>
-   <cc:Work rdf:about="">
-    <dc:format>image/svg+xml</dc:format>
-    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:title/>
-   </cc:Work>
-  </rdf:RDF>
- </metadata>
- <defs>
-  <linearGradient id="linearGradient2556" x1="-305" x2="-240" y1="38" y2="38" gradientTransform="matrix(.22387 0 0 .22387 54.931 -4.8242)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#505050" offset="0"/>
-   <stop stop-color="#323232" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient2652" x1="-261.67" x2="-240" y1="13" y2="13" gradientTransform="matrix(.22387 0 0 .22387 54.931 -4.8242)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#636363" offset="0"/>
-   <stop stop-color="#646464" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient2644" x1="-283.33" x2="-261.67" y1="13" y2="13" gradientTransform="matrix(.22387 0 0 .22387 54.931 -4.8242)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#989898" offset="0"/>
-   <stop stop-color="#999" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient2636" x1="-305" x2="-283.33" y1="13" y2="13" gradientTransform="matrix(.22387 0 0 .22387 54.931 -4.8242)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#cecece" offset="0"/>
-   <stop stop-color="#d0d0d0" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient2580" x1="-183.26" x2="-133.33" y1="-122.79" y2="-134.57" gradientTransform="matrix(.080469 0 0 .080469 2.3077 6.7492)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#a9a9a9" offset="0"/>
-   <stop stop-color="#8c8c8c" offset="1"/>
-  </linearGradient>
-  <filter id="filter2594" x="-.084" y="-.084" width="1.168" height="1.168" color-interpolation-filters="sRGB">
-   <feGaussianBlur stdDeviation="0.43959997"/>
-  </filter>
-  <linearGradient id="linearGradient2574" x1="-183.26" x2="-133.33" y1="-122.79" y2="-134.57" gradientTransform="matrix(.08047 0 0 .08047 7.5104 1.5352)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient2586"/>
-  <linearGradient id="linearGradient2586" x1="-183.26" x2="-133.33" y1="-122.79" y2="-134.57" gradientTransform="matrix(.25137 0 0 .25137 -7.3652 -24.336)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#e5e5e5" offset="0"/>
-   <stop stop-color="#cecece" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient2608" x1="-183.26" x2="-133.33" y1="-122.79" y2="-134.57" gradientTransform="matrix(.08047 0 0 .08047 10.094 4.6601)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient2586"/>
- </defs>
- <g transform="matrix(1.0909 0 0 1.0909 15.093 5.4256)">
-  <g stroke-width=".22387">
-   <path d="m1.2017-1.0184h-14.552v8.7311c0 0.37208 0.29954 0.67162 0.67162 0.67162h13.209c0.37208 0 0.67162-0.29954 0.67162-0.67162z" fill="url(#linearGradient2556)"/>
-   <path d="m-3.6497-2.8093v1.791h4.8504v-1.1194c0-0.37208-0.29954-0.67162-0.67162-0.67162z" fill="url(#linearGradient2652)"/>
-   <path d="m-8.4988-2.8093v1.791h4.8509v-1.791z" fill="url(#linearGradient2644)"/>
-   <path d="m-13.35-2.1377v1.1194h4.8504v-1.791h-4.1788c-0.37208 0-0.67162 0.29954-0.67162 0.67162z" fill="url(#linearGradient2636)"/>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="64" height="64" viewBox="0 0 64 64" version="1.1">
+<defs>
+<linearGradient id="linear0" gradientUnits="userSpaceOnUse" x1="-306.171" y1="15.2498" x2="-273.6694" y2="15.2498" gradientTransform="matrix(1.8462,0,0,-1.8462,567.2244,64.1528)">
+<stop offset="0" style="stop-color:rgb(31.372549%,31.372549%,31.372549%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(19.607843%,19.607843%,19.607843%);stop-opacity:1;"/>
+</linearGradient>
+<linearGradient id="linear1" gradientUnits="userSpaceOnUse" x1="-284.5038" y1="28.2501" x2="-273.6702" y2="28.2501" gradientTransform="matrix(1.8462,0,0,-1.8462,567.2244,64.1528)">
+<stop offset="0" style="stop-color:rgb(38.823529%,38.823529%,38.823529%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(39.215686%,39.215686%,39.215686%);stop-opacity:1;"/>
+</linearGradient>
+<linearGradient id="linear2" gradientUnits="userSpaceOnUse" x1="-295.3374" y1="28.2501" x2="-284.5038" y2="28.2501" gradientTransform="matrix(1.8462,0,0,-1.8462,567.2244,64.1528)">
+<stop offset="0" style="stop-color:rgb(59.607843%,59.607843%,59.607843%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(60%,60%,60%);stop-opacity:1;"/>
+</linearGradient>
+<linearGradient id="linear3" gradientUnits="userSpaceOnUse" x1="-306.171" y1="28.2501" x2="-295.3374" y2="28.2501" gradientTransform="matrix(1.8462,0,0,-1.8462,567.2244,64.1528)">
+<stop offset="0" style="stop-color:rgb(80.784314%,80.784314%,80.784314%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(81.568627%,81.568627%,81.568627%);stop-opacity:1;"/>
+</linearGradient>
+<linearGradient id="linear4" gradientUnits="userSpaceOnUse" x1="-142.9862" y1="223.0275" x2="-116.9567" y2="229.1687" gradientTransform="matrix(0.4692,-0.4692,-0.4692,-0.4692,183.9172,84.8652)">
+<stop offset="0" style="stop-color:rgb(66.27451%,66.27451%,66.27451%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(54.901961%,54.901961%,54.901961%);stop-opacity:1;"/>
+</linearGradient>
+<filter id="alpha" filterUnits="objectBoundingBox" x="0%" y="0%" width="100%" height="100%">
+  <feColorMatrix type="matrix" in="SourceGraphic" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"/>
+</filter>
+<image id="image9" width="64" height="64" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAABmJLR0QA/wD/AP+gvaeTAAAAhklEQVR4nO3XsQ3CUAwE0HxEZqCkQYI262UEFmAIJssMiRRG+IWJrsh7tWWfrvMwAAAAAABwHq03sK/TXD/z2Nr4fdf3/N+1O9Ge9/qZ21bfcYxLOkCaAtIB0hSQDpCmgHSANAWkA6QpIB0gTQHpAGmnL6D/Du+fpX7mtdZ3AAAAAAAAUPID5mAKIhibwwUAAAAASUVORK5CYII="/>
+<mask id="mask0">
+  <g filter="url(#alpha)">
+<use xlink:href="#image9"/>
   </g>
-  <rect transform="rotate(-45)" x="-12.577" y="-4.3857" width="4.426" height="1.4485" ry=".16094" fill="url(#linearGradient2580)" stroke-width=".080469"/>
-  <rect transform="matrix(.22636 .22636 .22636 -.22636 13.58 6.9821)" x="-68.454" y="-44.561" width="13.826" height="4.5247" ry=".50275" filter="url(#filter2594)" opacity=".6" stroke-width=".25137"/>
-  <rect transform="matrix(.70711 .70711 .70711 -.70711 0 0)" x="-7.3741" y="-9.5996" width="4.426" height="1.4485" ry=".16094" fill="url(#linearGradient2574)" stroke-width=".08047"/>
-  <rect transform="matrix(.32012 0 0 -.32012 17.123 -7.7903)" x="-68.454" y="-44.561" width="13.826" height="4.5247" ry=".50275" filter="url(#filter2594)" opacity=".6" stroke-width=".25137"/>
-  <rect transform="scale(1,-1)" x="-4.791" y="-6.4744" width="4.4259" height="1.4484" ry=".16094" fill="url(#linearGradient2608)" stroke-width=".08047"/>
- </g>
+</mask>
+<clipPath id="clip1">
+  <rect x="0" y="0" width="64" height="64"/>
+</clipPath>
+<g id="surface8" clip-path="url(#clip1)">
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(0%,0%,0%);fill-opacity:1;" d="M 8.210938 26.539062 L 21.179688 38.84375 C 21.46875 39.109375 21.90625 39.109375 22.195312 38.84375 L 25.757812 35.46875 C 25.890625 35.34375 25.96875 35.164062 25.96875 34.984375 C 25.96875 34.804688 25.890625 34.625 25.757812 34.5 L 12.789062 22.203125 C 12.5 21.9375 12.054688 21.9375 11.773438 22.203125 L 8.210938 25.578125 C 8.078125 25.703125 8 25.875 8 26.0625 C 8 26.242188 8.078125 26.414062 8.210938 26.539062 Z M 8.210938 26.539062 "/>
+</g>
+<linearGradient id="linear5" gradientUnits="userSpaceOnUse" x1="-224.7546" y1="141.1896" x2="-198.7251" y2="147.3308" gradientTransform="matrix(0.469236,0.469236,-0.469236,0.469236,183.8518,61.9014)">
+<stop offset="0" style="stop-color:rgb(89.803922%,89.803922%,89.803922%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(80.784314%,80.784314%,80.784314%);stop-opacity:1;"/>
+</linearGradient>
+<image id="image17" width="64" height="64" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAABmJLR0QA/wD/AP+gvaeTAAAAUUlEQVR4nO3QwQmAMBAEwJykSDuwJjuwSCFWkLxCDsPM9+B22VIAAAAAAAAAAAAA2FNkF+hp73nP+BP1uUb3Y0bInxkgu0A2A2QXAAAAAFjtA7p+BAwBvxIEAAAAAElFTkSuQmCC"/>
+<mask id="mask1">
+  <g filter="url(#alpha)">
+<use xlink:href="#image17"/>
+  </g>
+</mask>
+<clipPath id="clip2">
+  <rect x="0" y="0" width="64" height="64"/>
+</clipPath>
+<g id="surface16" clip-path="url(#clip2)">
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(0%,0%,0%);fill-opacity:1;" d="M 38.65625 48 L 55.34375 48 C 55.523438 48 55.6875 47.929688 55.8125 47.804688 C 55.9375 47.679688 56 47.507812 56 47.335938 L 56 42.664062 C 56 42.492188 55.9375 42.320312 55.8125 42.195312 C 55.6875 42.070312 55.523438 42 55.34375 42 L 38.65625 42 C 38.476562 42 38.3125 42.070312 38.1875 42.195312 C 38.0625 42.320312 38 42.492188 38 42.664062 L 38 47.335938 C 38 47.507812 38.0625 47.679688 38.1875 47.804688 C 38.3125 47.929688 38.476562 48 38.65625 48 Z M 38.65625 48 "/>
+</g>
+<linearGradient id="linear6" gradientUnits="userSpaceOnUse" x1="-241.3418" y1="90.8886" x2="-216.6895" y2="96.7048" gradientTransform="matrix(0.6636,0,0,0.6636,198.666,-17.3138)">
+<stop offset="0" style="stop-color:rgb(89.803922%,89.803922%,89.803922%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(80.784314%,80.784314%,80.784314%);stop-opacity:1;"/>
+</linearGradient>
+</defs>
+<g id="surface1">
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear0);" d="M 62 16 L 2 16 L 2 53.140625 C 1.984375 53.890625 2.273438 54.609375 2.789062 55.148438 C 3.3125 55.679688 4.023438 55.992188 4.765625 56 L 59.234375 56 C 59.976562 55.992188 60.6875 55.679688 61.210938 55.148438 C 61.726562 54.609375 62.015625 53.890625 62 53.140625 Z M 62 16 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear1);" d="M 42 8 L 42 16 L 62 16 L 62 11 C 62.03125 10.234375 61.757812 9.492188 61.234375 8.929688 C 60.71875 8.367188 59.992188 8.03125 59.234375 8 Z M 42 8 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear2);" d="M 22 8 L 22 16 L 42 16 L 42 8 Z M 22 8 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear3);" d="M 2 11 L 2 16 L 22 16 L 22 8 L 4.765625 8 C 4.007812 8.03125 3.28125 8.367188 2.765625 8.929688 C 2.242188 9.492188 1.96875 10.234375 2 11 Z M 2 11 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear4);" d="M 8.242188 43.460938 L 21.210938 31.15625 C 21.5 30.890625 21.945312 30.890625 22.226562 31.15625 L 25.789062 34.53125 C 25.921875 34.65625 26 34.835938 26 35.015625 C 26 35.203125 25.921875 35.375 25.789062 35.5 L 12.820312 47.796875 C 12.539062 48.0625 12.09375 48.0625 11.804688 47.796875 L 8.242188 44.421875 C 8.109375 44.296875 8.03125 44.125 8.03125 43.9375 C 8.03125 43.757812 8.109375 43.585938 8.242188 43.460938 Z M 8.242188 43.460938 "/>
+<use xlink:href="#surface8" mask="url(#mask0)"/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear5);" d="M 8.210938 26.539062 L 21.179688 38.84375 C 21.460938 39.109375 21.90625 39.109375 22.195312 38.84375 L 25.757812 35.46875 C 25.890625 35.34375 25.96875 35.164062 25.96875 34.984375 C 25.96875 34.796875 25.890625 34.625 25.757812 34.5 L 12.789062 22.203125 C 12.5 21.9375 12.054688 21.9375 11.773438 22.203125 L 8.210938 25.578125 C 8.078125 25.703125 8 25.875 8 26.0625 C 8 26.242188 8.078125 26.414062 8.210938 26.539062 Z M 8.210938 26.539062 "/>
+<use xlink:href="#surface16" mask="url(#mask1)"/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear6);" d="M 38.65625 48 L 55.34375 48 C 55.523438 48 55.6875 47.929688 55.8125 47.804688 C 55.9375 47.679688 56 47.507812 56 47.335938 L 56 42.664062 C 56 42.492188 55.9375 42.320312 55.8125 42.195312 C 55.6875 42.070312 55.523438 42 55.34375 42 L 38.65625 42 C 38.476562 42 38.3125 42.070312 38.1875 42.195312 C 38.0625 42.320312 38 42.492188 38 42.664062 L 38 47.335938 C 38 47.507812 38.0625 47.679688 38.1875 47.804688 C 38.3125 47.929688 38.476562 48 38.65625 48 Z M 38.65625 48 "/>
+</g>
 </svg>

--- a/src/apps/scalable/yakuake.svg
+++ b/src/apps/scalable/yakuake.svg
@@ -1,56 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="64" height="64" version="1.1" viewBox="0 0 16.933 16.933" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
- <metadata>
-  <rdf:RDF>
-   <cc:Work rdf:about="">
-    <dc:format>image/svg+xml</dc:format>
-    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:title/>
-   </cc:Work>
-  </rdf:RDF>
- </metadata>
- <defs>
-  <linearGradient id="linearGradient2556" x1="-305" x2="-240" y1="38" y2="38" gradientTransform="matrix(.22387 0 0 .22387 54.931 -4.8242)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#505050" offset="0"/>
-   <stop stop-color="#323232" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient2652" x1="-261.67" x2="-240" y1="13" y2="13" gradientTransform="matrix(.22387 0 0 .22387 54.931 -4.8242)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#636363" offset="0"/>
-   <stop stop-color="#646464" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient2644" x1="-283.33" x2="-261.67" y1="13" y2="13" gradientTransform="matrix(.22387 0 0 .22387 54.931 -4.8242)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#989898" offset="0"/>
-   <stop stop-color="#999" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient2636" x1="-305" x2="-283.33" y1="13" y2="13" gradientTransform="matrix(.22387 0 0 .22387 54.931 -4.8242)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#cecece" offset="0"/>
-   <stop stop-color="#d0d0d0" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient2580" x1="-183.26" x2="-133.33" y1="-122.79" y2="-134.57" gradientTransform="matrix(.080469 0 0 .080469 2.3077 6.7492)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#a9a9a9" offset="0"/>
-   <stop stop-color="#8c8c8c" offset="1"/>
-  </linearGradient>
-  <filter id="filter2594" x="-.084" y="-.084" width="1.168" height="1.168" color-interpolation-filters="sRGB">
-   <feGaussianBlur stdDeviation="0.43959997"/>
-  </filter>
-  <linearGradient id="linearGradient2574" x1="-183.26" x2="-133.33" y1="-122.79" y2="-134.57" gradientTransform="matrix(.08047 0 0 .08047 7.5104 1.5352)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient2586"/>
-  <linearGradient id="linearGradient2586" x1="-183.26" x2="-133.33" y1="-122.79" y2="-134.57" gradientTransform="matrix(.25137 0 0 .25137 -7.3652 -24.336)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#e5e5e5" offset="0"/>
-   <stop stop-color="#cecece" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient2608" x1="-183.26" x2="-133.33" y1="-122.79" y2="-134.57" gradientTransform="matrix(.08047 0 0 .08047 10.094 4.6601)" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient2586"/>
- </defs>
- <g transform="matrix(1.0909 0 0 1.0909 15.093 5.4256)">
-  <g stroke-width=".22387">
-   <path d="m1.2017-1.0184h-14.552v8.7311c0 0.37208 0.29954 0.67162 0.67162 0.67162h13.209c0.37208 0 0.67162-0.29954 0.67162-0.67162z" fill="url(#linearGradient2556)"/>
-   <path d="m-3.6497-2.8093v1.791h4.8504v-1.1194c0-0.37208-0.29954-0.67162-0.67162-0.67162z" fill="url(#linearGradient2652)"/>
-   <path d="m-8.4988-2.8093v1.791h4.8509v-1.791z" fill="url(#linearGradient2644)"/>
-   <path d="m-13.35-2.1377v1.1194h4.8504v-1.791h-4.1788c-0.37208 0-0.67162 0.29954-0.67162 0.67162z" fill="url(#linearGradient2636)"/>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="64" height="64" viewBox="0 0 64 64" version="1.1">
+<defs>
+<linearGradient id="linear0" gradientUnits="userSpaceOnUse" x1="-306.171" y1="15.2498" x2="-273.6694" y2="15.2498" gradientTransform="matrix(1.8462,0,0,-1.8462,567.2244,64.1528)">
+<stop offset="0" style="stop-color:rgb(31.372549%,31.372549%,31.372549%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(19.607843%,19.607843%,19.607843%);stop-opacity:1;"/>
+</linearGradient>
+<linearGradient id="linear1" gradientUnits="userSpaceOnUse" x1="-284.5038" y1="28.2501" x2="-273.6702" y2="28.2501" gradientTransform="matrix(1.8462,0,0,-1.8462,567.2244,64.1528)">
+<stop offset="0" style="stop-color:rgb(38.823529%,38.823529%,38.823529%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(39.215686%,39.215686%,39.215686%);stop-opacity:1;"/>
+</linearGradient>
+<linearGradient id="linear2" gradientUnits="userSpaceOnUse" x1="-295.3374" y1="28.2501" x2="-284.5038" y2="28.2501" gradientTransform="matrix(1.8462,0,0,-1.8462,567.2244,64.1528)">
+<stop offset="0" style="stop-color:rgb(59.607843%,59.607843%,59.607843%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(60%,60%,60%);stop-opacity:1;"/>
+</linearGradient>
+<linearGradient id="linear3" gradientUnits="userSpaceOnUse" x1="-306.171" y1="28.2501" x2="-295.3374" y2="28.2501" gradientTransform="matrix(1.8462,0,0,-1.8462,567.2244,64.1528)">
+<stop offset="0" style="stop-color:rgb(80.784314%,80.784314%,80.784314%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(81.568627%,81.568627%,81.568627%);stop-opacity:1;"/>
+</linearGradient>
+<linearGradient id="linear4" gradientUnits="userSpaceOnUse" x1="-142.9862" y1="223.0275" x2="-116.9567" y2="229.1687" gradientTransform="matrix(0.4692,-0.4692,-0.4692,-0.4692,183.9172,84.8652)">
+<stop offset="0" style="stop-color:rgb(66.27451%,66.27451%,66.27451%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(54.901961%,54.901961%,54.901961%);stop-opacity:1;"/>
+</linearGradient>
+<filter id="alpha" filterUnits="objectBoundingBox" x="0%" y="0%" width="100%" height="100%">
+  <feColorMatrix type="matrix" in="SourceGraphic" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"/>
+</filter>
+<image id="image9" width="64" height="64" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAABmJLR0QA/wD/AP+gvaeTAAAAhklEQVR4nO3XsQ3CUAwE0HxEZqCkQYI262UEFmAIJssMiRRG+IWJrsh7tWWfrvMwAAAAAABwHq03sK/TXD/z2Nr4fdf3/N+1O9Ge9/qZ21bfcYxLOkCaAtIB0hSQDpCmgHSANAWkA6QpIB0gTQHpAGmnL6D/Du+fpX7mtdZ3AAAAAAAAUPID5mAKIhibwwUAAAAASUVORK5CYII="/>
+<mask id="mask0">
+  <g filter="url(#alpha)">
+<use xlink:href="#image9"/>
   </g>
-  <rect transform="rotate(-45)" x="-12.577" y="-4.3857" width="4.426" height="1.4485" ry=".16094" fill="url(#linearGradient2580)" stroke-width=".080469"/>
-  <rect transform="matrix(.22636 .22636 .22636 -.22636 13.58 6.9821)" x="-68.454" y="-44.561" width="13.826" height="4.5247" ry=".50275" filter="url(#filter2594)" opacity=".6" stroke-width=".25137"/>
-  <rect transform="matrix(.70711 .70711 .70711 -.70711 0 0)" x="-7.3741" y="-9.5996" width="4.426" height="1.4485" ry=".16094" fill="url(#linearGradient2574)" stroke-width=".08047"/>
-  <rect transform="matrix(.32012 0 0 -.32012 17.123 -7.7903)" x="-68.454" y="-44.561" width="13.826" height="4.5247" ry=".50275" filter="url(#filter2594)" opacity=".6" stroke-width=".25137"/>
-  <rect transform="scale(1,-1)" x="-4.791" y="-6.4744" width="4.4259" height="1.4484" ry=".16094" fill="url(#linearGradient2608)" stroke-width=".08047"/>
- </g>
+</mask>
+<clipPath id="clip1">
+  <rect x="0" y="0" width="64" height="64"/>
+</clipPath>
+<g id="surface8" clip-path="url(#clip1)">
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(0%,0%,0%);fill-opacity:1;" d="M 8.210938 26.539062 L 21.179688 38.84375 C 21.46875 39.109375 21.90625 39.109375 22.195312 38.84375 L 25.757812 35.46875 C 25.890625 35.34375 25.96875 35.164062 25.96875 34.984375 C 25.96875 34.804688 25.890625 34.625 25.757812 34.5 L 12.789062 22.203125 C 12.5 21.9375 12.054688 21.9375 11.773438 22.203125 L 8.210938 25.578125 C 8.078125 25.703125 8 25.875 8 26.0625 C 8 26.242188 8.078125 26.414062 8.210938 26.539062 Z M 8.210938 26.539062 "/>
+</g>
+<linearGradient id="linear5" gradientUnits="userSpaceOnUse" x1="-224.7546" y1="141.1896" x2="-198.7251" y2="147.3308" gradientTransform="matrix(0.469236,0.469236,-0.469236,0.469236,183.8518,61.9014)">
+<stop offset="0" style="stop-color:rgb(89.803922%,89.803922%,89.803922%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(80.784314%,80.784314%,80.784314%);stop-opacity:1;"/>
+</linearGradient>
+<image id="image17" width="64" height="64" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAABmJLR0QA/wD/AP+gvaeTAAAAUUlEQVR4nO3QwQmAMBAEwJykSDuwJjuwSCFWkLxCDsPM9+B22VIAAAAAAAAAAAAA2FNkF+hp73nP+BP1uUb3Y0bInxkgu0A2A2QXAAAAAFjtA7p+BAwBvxIEAAAAAElFTkSuQmCC"/>
+<mask id="mask1">
+  <g filter="url(#alpha)">
+<use xlink:href="#image17"/>
+  </g>
+</mask>
+<clipPath id="clip2">
+  <rect x="0" y="0" width="64" height="64"/>
+</clipPath>
+<g id="surface16" clip-path="url(#clip2)">
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(0%,0%,0%);fill-opacity:1;" d="M 38.65625 48 L 55.34375 48 C 55.523438 48 55.6875 47.929688 55.8125 47.804688 C 55.9375 47.679688 56 47.507812 56 47.335938 L 56 42.664062 C 56 42.492188 55.9375 42.320312 55.8125 42.195312 C 55.6875 42.070312 55.523438 42 55.34375 42 L 38.65625 42 C 38.476562 42 38.3125 42.070312 38.1875 42.195312 C 38.0625 42.320312 38 42.492188 38 42.664062 L 38 47.335938 C 38 47.507812 38.0625 47.679688 38.1875 47.804688 C 38.3125 47.929688 38.476562 48 38.65625 48 Z M 38.65625 48 "/>
+</g>
+<linearGradient id="linear6" gradientUnits="userSpaceOnUse" x1="-241.3418" y1="90.8886" x2="-216.6895" y2="96.7048" gradientTransform="matrix(0.6636,0,0,0.6636,198.666,-17.3138)">
+<stop offset="0" style="stop-color:rgb(89.803922%,89.803922%,89.803922%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(80.784314%,80.784314%,80.784314%);stop-opacity:1;"/>
+</linearGradient>
+</defs>
+<g id="surface1">
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear0);" d="M 62 16 L 2 16 L 2 53.140625 C 1.984375 53.890625 2.273438 54.609375 2.789062 55.148438 C 3.3125 55.679688 4.023438 55.992188 4.765625 56 L 59.234375 56 C 59.976562 55.992188 60.6875 55.679688 61.210938 55.148438 C 61.726562 54.609375 62.015625 53.890625 62 53.140625 Z M 62 16 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear1);" d="M 42 8 L 42 16 L 62 16 L 62 11 C 62.03125 10.234375 61.757812 9.492188 61.234375 8.929688 C 60.71875 8.367188 59.992188 8.03125 59.234375 8 Z M 42 8 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear2);" d="M 22 8 L 22 16 L 42 16 L 42 8 Z M 22 8 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear3);" d="M 2 11 L 2 16 L 22 16 L 22 8 L 4.765625 8 C 4.007812 8.03125 3.28125 8.367188 2.765625 8.929688 C 2.242188 9.492188 1.96875 10.234375 2 11 Z M 2 11 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear4);" d="M 8.242188 43.460938 L 21.210938 31.15625 C 21.5 30.890625 21.945312 30.890625 22.226562 31.15625 L 25.789062 34.53125 C 25.921875 34.65625 26 34.835938 26 35.015625 C 26 35.203125 25.921875 35.375 25.789062 35.5 L 12.820312 47.796875 C 12.539062 48.0625 12.09375 48.0625 11.804688 47.796875 L 8.242188 44.421875 C 8.109375 44.296875 8.03125 44.125 8.03125 43.9375 C 8.03125 43.757812 8.109375 43.585938 8.242188 43.460938 Z M 8.242188 43.460938 "/>
+<use xlink:href="#surface8" mask="url(#mask0)"/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear5);" d="M 8.210938 26.539062 L 21.179688 38.84375 C 21.460938 39.109375 21.90625 39.109375 22.195312 38.84375 L 25.757812 35.46875 C 25.890625 35.34375 25.96875 35.164062 25.96875 34.984375 C 25.96875 34.796875 25.890625 34.625 25.757812 34.5 L 12.789062 22.203125 C 12.5 21.9375 12.054688 21.9375 11.773438 22.203125 L 8.210938 25.578125 C 8.078125 25.703125 8 25.875 8 26.0625 C 8 26.242188 8.078125 26.414062 8.210938 26.539062 Z M 8.210938 26.539062 "/>
+<use xlink:href="#surface16" mask="url(#mask1)"/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear6);" d="M 38.65625 48 L 55.34375 48 C 55.523438 48 55.6875 47.929688 55.8125 47.804688 C 55.9375 47.679688 56 47.507812 56 47.335938 L 56 42.664062 C 56 42.492188 55.9375 42.320312 55.8125 42.195312 C 55.6875 42.070312 55.523438 42 55.34375 42 L 38.65625 42 C 38.476562 42 38.3125 42.070312 38.1875 42.195312 C 38.0625 42.320312 38 42.492188 38 42.664062 L 38 47.335938 C 38 47.507812 38.0625 47.679688 38.1875 47.804688 C 38.3125 47.929688 38.476562 48 38.65625 48 Z M 38.65625 48 "/>
+</g>
 </svg>


### PR DESCRIPTION
A better solution for this [Pull Request](https://github.com/yeyushengfan258/Win11-icon-theme/pull/6).
Resolution fix for resolutions multiples of 32. 32x32, 64x64, 96x96, 128x128, 256x256.