### PR TITLE
Evince

### DIFF
--- a/links/apps/scalable/evince.svg
+++ b/links/apps/scalable/evince.svg
@@ -1,1 +1,0 @@
-accessories-document-viewer.svg

--- a/src/apps/scalable/evince.svg
+++ b/src/apps/scalable/evince.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="64" height="64" viewBox="0 0 64 64" version="1.1">
+<defs>
+<linearGradient id="linear0" gradientUnits="userSpaceOnUse" x1="16" y1="2" x2="16" y2="30" gradientTransform="matrix(2,0,0,2,0,0)">
+<stop offset="0" style="stop-color:rgb(100%,100%,100%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(89.411765%,89.411765%,89.411765%);stop-opacity:1;"/>
+</linearGradient>
+<filter id="alpha" filterUnits="objectBoundingBox" x="0%" y="0%" width="100%" height="100%">
+  <feColorMatrix type="matrix" in="SourceGraphic" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"/>
+</filter>
+<mask id="mask0">
+  <g filter="url(#alpha)">
+<rect x="0" y="0" width="64" height="64" style="fill:rgb(0%,0%,0%);fill-opacity:0.2;stroke:none;"/>
+  </g>
+</mask>
+<clipPath id="clip1">
+  <rect x="0" y="0" width="64" height="64"/>
+</clipPath>
+<g id="surface5" clip-path="url(#clip1)">
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(0%,0%,0%);fill-opacity:1;" d="M 14 44 L 14 50 L 46 50 L 46 48 L 50 48 L 50 44 Z M 14 44 "/>
+</g>
+<linearGradient id="linear1" gradientUnits="userSpaceOnUse" x1="20.997" y1="11" x2="20.997" y2="19" gradientTransform="matrix(2,0,0,2,0,0)">
+<stop offset="0.4413" style="stop-color:rgb(100%,30.196078%,22.352941%);stop-opacity:1;"/>
+<stop offset="0.5726" style="stop-color:rgb(98.823529%,29.411765%,22.352941%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(80%,20%,20%);stop-opacity:1;"/>
+</linearGradient>
+<mask id="mask1">
+  <g filter="url(#alpha)">
+<rect x="0" y="0" width="64" height="64" style="fill:rgb(0%,0%,0%);fill-opacity:0.4;stroke:none;"/>
+  </g>
+</mask>
+<clipPath id="clip2">
+  <rect x="0" y="0" width="64" height="64"/>
+</clipPath>
+<g id="surface8" clip-path="url(#clip2)">
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(0%,0%,0%);fill-opacity:1;" d="M 14 10 L 14 12 L 34 12 L 34 10 Z M 14 10 "/>
+</g>
+<mask id="mask2">
+  <g filter="url(#alpha)">
+<rect x="0" y="0" width="64" height="64" style="fill:rgb(0%,0%,0%);fill-opacity:0.2;stroke:none;"/>
+  </g>
+</mask>
+<clipPath id="clip3">
+  <rect x="0" y="0" width="64" height="64"/>
+</clipPath>
+<g id="surface11" clip-path="url(#clip3)">
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(0%,0%,0%);fill-opacity:1;" d="M 30 18 L 30 26 L 14 26 L 14 16 L 50 16 L 50 18 Z M 30 18 "/>
+</g>
+<mask id="mask3">
+  <g filter="url(#alpha)">
+<rect x="0" y="0" width="64" height="64" style="fill:rgb(0%,0%,0%);fill-opacity:0.2;stroke:none;"/>
+  </g>
+</mask>
+<clipPath id="clip4">
+  <rect x="0" y="0" width="64" height="64"/>
+</clipPath>
+<g id="surface14" clip-path="url(#clip4)">
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(0%,0%,0%);fill-opacity:1;" d="M 14 30 L 30 30 L 30 38 L 24 38 L 24 40 L 14 40 Z M 14 30 "/>
+</g>
+</defs>
+<g id="surface1">
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear0);" d="M 14.199219 4 L 49.800781 4 C 52.121094 4 54 5.878906 54 8.199219 L 54 55.800781 C 54 58.121094 52.121094 60 49.800781 60 L 14.199219 60 C 11.878906 60 10 58.121094 10 55.800781 L 10 8.199219 C 10 5.878906 11.878906 4 14.199219 4 Z M 14.199219 4 "/>
+<use xlink:href="#surface5" mask="url(#mask0)"/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear1);" d="M 34 22 L 49.988281 22 L 49.988281 38 L 34 38 Z M 34 22 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:1;" d="M 34.253906 34.605469 C 37.328125 33.921875 40.203125 32.542969 42.65625 30.570312 C 43.703125 29.613281 44.148438 28.160156 43.816406 26.777344 C 43.117188 25.503906 41.648438 24.855469 40.234375 25.199219 C 38.1875 25.597656 36.578125 27.179688 36.148438 29.21875 C 36.054688 30.902344 37.070312 32.449219 38.652344 33.03125 C 40.703125 34.011719 43.027344 34.265625 45.242188 33.742188 C 46.921875 33.433594 48.535156 32.828125 50 31.949219 L 49.988281 29.355469 C 47.570312 31.785156 44.222656 33.054688 40.796875 32.839844 C 39.21875 32.707031 37.429688 32.171875 36.980469 30.566406 C 36.691406 28.945312 37.472656 27.320312 38.921875 26.535156 C 39.96875 25.882812 41.28125 25.828125 42.378906 26.386719 C 43.179688 27.25 43.25 28.558594 42.554688 29.507812 C 41.378906 30.660156 40.023438 31.621094 38.546875 32.351562 C 37.199219 33.25 35.757812 34.003906 34.253906 34.605469 Z M 34.253906 34.605469 "/>
+<use xlink:href="#surface8" mask="url(#mask1)"/>
+<use xlink:href="#surface11" mask="url(#mask2)"/>
+<use xlink:href="#surface14" mask="url(#mask3)"/>
+</g>
+</svg>


### PR DESCRIPTION
I made this version of Papirus icon for evince with microsoft fluent style.
It's necessary to fix org.gnome.Evince.svg symbolic link redirecting to "accessories-document-viewer.svg".
![evince](https://user-images.githubusercontent.com/31783838/133950156-dd3b0b32-36f7-4bc1-b786-e5df9ddd6230.png)
