### PR TITLE
Sound Recorder pixel grid fix

### DIFF
--- a/src/apps/scalable/gnome-sound-recorder.svg
+++ b/src/apps/scalable/gnome-sound-recorder.svg
@@ -1,70 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg width="64" height="64" version="1.1" viewBox="0 0 16.933 16.933" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
- <defs>
-  <linearGradient id="i" x1="400.4" x2="400.4" y1="545.62" y2="517.62" gradientTransform="matrix(.41967 0 0 .41967 -173.34 -178.23)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#d3d3d3" offset="0"/>
-   <stop stop-color="#fcf9f9" offset="1"/>
-  </linearGradient>
-  <linearGradient id="f" x1="400.4" x2="400.4" y1="545.62" y2="517.62" gradientTransform="matrix(.43343 0 0 .43343 -193.09 -179.69)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#8d3aff" offset="0"/>
-   <stop stop-color="#ff3680" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient980" x1="125.41" x2="125.41" y1="7.1436" y2="15.081" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#a0aab3" offset="0"/>
-   <stop stop-color="#838c91" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient994" x1="125.67" x2="125.67" y1="1.0583" y2="8.2066" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#a0aab4" offset="0"/>
-   <stop stop-color="#8c969b" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient1002" x1="125.67" x2="125.67" y1="8.2066" y2="12.015" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#696e73" offset="0"/>
-   <stop stop-color="#32373c" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient1017" x1="475" x2="475" y1="56.949" y2="69" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#9fa9b3" offset="0"/>
-   <stop stop-color="#788287" offset="1"/>
-  </linearGradient>
-  <filter id="filter1045" x="-.168" y="-.42" width="1.336" height="1.84" color-interpolation-filters="sRGB">
-   <feGaussianBlur stdDeviation="0.092602345"/>
-  </filter>
-  <linearGradient id="linearGradient1057" x1="124.62" x2="125.94" y1="9.5248" y2="10.848" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#e16e32" offset="0"/>
-   <stop stop-color="#d24114" offset="1"/>
-  </linearGradient>
- </defs>
- <metadata>
-  <rdf:RDF>
-   <cc:Work rdf:about="">
-    <dc:format>image/svg+xml</dc:format>
-    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:title/>
-   </cc:Work>
-  </rdf:RDF>
- </metadata>
- <g transform="translate(-21.834 .89695)" fill="#5e4aa6" stroke-width=".26458">
-  <circle cx="-330.35" cy="-328.38" r="0"/>
-  <circle cx="-312.11" cy="-326.25" r="0"/>
-  <circle cx="-306.02" cy="-333.07" r="0"/>
-  <circle cx="-308.84" cy="-326.01" r="0"/>
- </g>
- <circle cx="-5.2346" cy="44.956" r="0" fill="url(#i)" image-rendering="optimizeSpeed" stroke-width=".26458"/>
- <circle cx="-19.466" cy="50.818" r="0" fill="none" image-rendering="optimizeSpeed" stroke="url(#f)" stroke-width=".56347"/>
- <g transform="translate(-21.834 .89695)" fill="#5e4aa6" stroke-width=".26458">
-  <circle cx="-330.35" cy="-328.38" r="0"/>
-  <circle cx="-312.11" cy="-326.25" r="0"/>
-  <circle cx="-306.02" cy="-333.07" r="0"/>
-  <circle cx="-308.84" cy="-326.01" r="0"/>
- </g>
- <g transform="matrix(.9375 0 0 .9375 -21.671 -.46301)">
-  <g transform="translate(-93.132)">
-   <path transform="scale(.26458)" d="m471 57v6h-8c-0.55388 0-1 0.44612-1 1v3c0 0.55388 0.44612 1 1 1h21c0.55388 0 1-0.44612 1-1v-3c0-0.55388-0.44612-1-1-1h-8v-6z" fill="url(#linearGradient1017)"/>
-   <path d="m121.71 8.2019v3.4395c0 0.29315 0.25489 0.52916 0.57149 0.52916h6.0006c0.3166 0 0.57149-0.236 0.57149-0.52916v-3.4395z" fill="url(#linearGradient1002)"/>
-   <path d="m121.71 8.2019h7.1436v-6.6145c0-0.29315-0.25489-0.52916-0.57149-0.52916h-6.0006c-0.3166 0-0.57149 0.236-0.57149 0.52916z" fill="url(#linearGradient994)"/>
-   <rect x="124.62" y="14.816" width="1.3229" height=".52916" filter="url(#filter1045)" opacity=".3"/>
-   <path d="m120.65 7.1436c-0.0733 0-0.13924 0.029691-0.18706 0.077513-0.0478 0.047823-0.0775 0.11378-0.0775 0.18706v5.2916c0 1.3192 1.062 2.3812 2.3812 2.3812h5.027c1.3192 0 2.3812-1.062 2.3812-2.3812v-5.2916c0-0.073288-0.0297-0.13924-0.0775-0.18706-0.0478-0.047822-0.11378-0.077513-0.18706-0.077513h-0.79374c-0.0733 0-0.13924 0.029691-0.18706 0.077513-0.0478 0.047823-0.0775 0.11378-0.0775 0.18706v5.3773c0 0.53878-0.43375 0.97253-0.97253 0.97253h-5.1985c-0.53877 0-0.97254-0.43376-0.97254-0.97253v-5.3773c0-0.073288-0.0297-0.13924-0.0775-0.18706-0.0478-0.047822-0.11378-0.077513-0.18706-0.077513z" fill="url(#linearGradient980)"/>
-   <circle cx="125.28" cy="10.186" r="1.0583" fill="url(#linearGradient1057)"/>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="64" height="64" viewBox="0 0 64 64" version="1.1">
+<defs>
+<linearGradient id="linear0" gradientUnits="userSpaceOnUse" x1="16" y1="25" x2="16" y2="32" gradientTransform="matrix(2,0,0,2,0,0)">
+<stop offset="0" style="stop-color:rgb(62.352941%,66.27451%,70.196078%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(47.058824%,50.980392%,52.941176%);stop-opacity:1;"/>
+</linearGradient>
+<linearGradient id="linear1" gradientUnits="userSpaceOnUse" x1="120.1155" y1="29.1579" x2="122.7437" y2="26.5297" gradientTransform="matrix(7.0868,0,0,-7.0868,-828.9058,232.3628)">
+<stop offset="0" style="stop-color:rgb(40%,42.352941%,44.313725%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(19.607843%,20.784314%,21.568627%);stop-opacity:1;"/>
+</linearGradient>
+<linearGradient id="linear2" gradientUnits="userSpaceOnUse" x1="121.481" y1="32.7883" x2="121.481" y2="28.8373" gradientTransform="matrix(7.0868,0,0,-7.0868,-828.9058,232.3628)">
+<stop offset="0.2961" style="stop-color:rgb(62.352941%,65.882353%,69.019608%);stop-opacity:1;"/>
+<stop offset="0.9274" style="stop-color:rgb(53.72549%,56.862745%,59.607843%);stop-opacity:1;"/>
+</linearGradient>
+<linearGradient id="linear3" gradientUnits="userSpaceOnUse" x1="14.7539" y1="16.7516" x2="17.2515" y2="19.2492" gradientTransform="matrix(2,0,0,2,0,0)">
+<stop offset="0" style="stop-color:rgb(96.078431%,36.862745%,9.803922%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(93.333333%,25.490196%,0%);stop-opacity:1;"/>
+</linearGradient>
+<filter id="alpha" filterUnits="objectBoundingBox" x="0%" y="0%" width="100%" height="100%">
+  <feColorMatrix type="matrix" in="SourceGraphic" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"/>
+</filter>
+<mask id="mask0">
+  <g filter="url(#alpha)">
+<rect x="0" y="0" width="64" height="64" style="fill:rgb(0%,0%,0%);fill-opacity:0.301961;stroke:none;"/>
   </g>
- </g>
+</mask>
+<linearGradient id="linear4" gradientUnits="userSpaceOnUse" x1="16" y1="28" x2="16" y2="27" gradientTransform="matrix(2,0,0,2,0,0)">
+<stop offset="0" style="stop-color:rgb(0%,0%,0%);stop-opacity:0;"/>
+<stop offset="1" style="stop-color:rgb(0%,0%,0%);stop-opacity:1;"/>
+</linearGradient>
+<clipPath id="clip1">
+  <rect x="0" y="0" width="64" height="64"/>
+</clipPath>
+<g id="surface5" clip-path="url(#clip1)">
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear4);" d="M 28 54 L 36 54 L 36 56 L 28 56 Z M 28 54 "/>
+</g>
+<linearGradient id="linear5" gradientUnits="userSpaceOnUse" x1="8.466" y1="11.0547" x2="23.534" y2="26.1228" gradientTransform="matrix(2,0,0,2,0,0)">
+<stop offset="0" style="stop-color:rgb(61.960784%,65.490196%,69.019608%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(45.490196%,49.411765%,53.333333%);stop-opacity:1;"/>
+</linearGradient>
+</defs>
+<g id="surface1">
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear0);" d="M 42.925781 60 L 36 60 L 36 50 L 28 50 L 28 60 L 21.074219 60 C 20.480469 60 20 60.480469 20 61.074219 L 20 62.925781 C 20 63.519531 20.480469 64 21.074219 64 L 42.925781 64 C 43.519531 64 44 63.519531 44 62.925781 L 44 61.074219 C 44 60.480469 43.519531 60 42.925781 60 Z M 42.925781 60 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear1);" d="M 20.003906 28 L 20.003906 41.867188 C 19.945312 42.984375 20.804688 43.941406 21.925781 44 L 42.085938 44 C 43.203125 43.941406 44.0625 42.984375 44.003906 41.867188 L 44.003906 28 Z M 20.003906 28 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear2);" d="M 20 28 L 44 28 L 44 2.074219 C 44.019531 1.542969 43.828125 1.027344 43.46875 0.640625 C 43.109375 0.25 42.609375 0.0195312 42.078125 0 L 21.921875 0 C 21.390625 0.0195312 20.890625 0.25 20.53125 0.640625 C 20.171875 1.027344 19.980469 1.542969 20 2.074219 Z M 20 28 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear3);" d="M 36.003906 36 C 36.003906 38.210938 34.214844 40 32.003906 40 C 29.796875 40 28.003906 38.210938 28.003906 36 C 28.003906 33.789062 29.796875 32 32.003906 32 C 34.214844 32 36.003906 33.789062 36.003906 36 Z M 36.003906 36 "/>
+<use xlink:href="#surface5" mask="url(#mask0)"/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear5);" d="M 48.222656 24 L 45.777344 24 C 44.796875 24 44 24.796875 44 25.777344 L 44 45 C 44 46.65625 42.65625 48 41 48 L 23 48 C 21.34375 48 20 46.65625 20 45 L 20 25.777344 C 20 24.796875 19.203125 24 18.222656 24 L 15.777344 24 C 14.796875 24 14 24.796875 14 25.777344 L 14 46 C 14 50.417969 17.582031 54 22 54 L 42 54 C 46.417969 54 50 50.417969 50 46 L 50 25.777344 C 50 24.796875 49.203125 24 48.222656 24 Z M 48.222656 24 "/>
+</g>
 </svg>


### PR DESCRIPTION
Resolution fix for resolutions multiples of 32. 32x32, 64x64, 96x96, 128x128, 256x256.
![gnome-sound-recorder](https://user-images.githubusercontent.com/31783838/134260488-8798b3c4-866f-42ea-818c-a35124bcac69.png)
![PaintDotNet_zk9xTqIX5W](https://user-images.githubusercontent.com/31783838/134260593-3d5cef6e-1b33-4434-9635-02c3e661906c.png)

Current icon:
![PaintDotNet_5CTMZXQuho](https://user-images.githubusercontent.com/31783838/134260706-515e0928-4a35-4dcb-9ef5-cfae0312cb42.png)

Windows original icon:
![64x64](https://user-images.githubusercontent.com/31783838/134260772-e10b8385-5d5b-41dd-9c71-0203aa34ee9a.png)


