### PR TITLE
Desktop icon change for original Window 11 style

### DIFF
--- a/src/apps/scalable/desktop.svg
+++ b/src/apps/scalable/desktop.svg
@@ -9,13 +9,42 @@
 <stop offset="0" style="stop-color:rgb(25.882353%,89.019608%,90.588235%);stop-opacity:1;"/>
 <stop offset="1" style="stop-color:rgb(3.529412%,43.529412%,74.509804%);stop-opacity:1;"/>
 </linearGradient>
+<filter id="alpha" filterUnits="objectBoundingBox" x="0%" y="0%" width="100%" height="100%">
+  <feColorMatrix type="matrix" in="SourceGraphic" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"/>
+</filter>
+<mask id="mask0">
+  <g filter="url(#alpha)">
+<rect x="0" y="0" width="64" height="64" style="fill:rgb(0%,0%,0%);fill-opacity:0.101961;stroke:none;"/>
+  </g>
+</mask>
+<image id="image6" width="9" height="9" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAJCAYAAADgkQYQAAAABmJLR0QA/wD/AP+gvaeTAAAAeklEQVQYlY3QsQoCQQyE4W/dFQTRQlsF4d7B2vd/Da8VRRv1XM8m4mEhpkmG/IGZJJ9Kg97H3A8XIxRMkFFxxQPPHOAYSzTYYI4OtyE0DWCHLRY44oR7CSjH9SpgoTNSCXMVZ7QBtKEr+vTlaY0ZLtjjgO6vdG/o559eaUMfCMRK6YkAAAAASUVORK5CYII="/>
+<clipPath id="clip1">
+  <rect x="0" y="0" width="64" height="64"/>
+</clipPath>
+<g id="surface7" clip-path="url(#clip1)">
+<use xlink:href="#image6" transform="matrix(2,0,0,2,0,20)"/>
+</g>
+<mask id="mask1">
+  <g filter="url(#alpha)">
+<rect x="0" y="0" width="64" height="64" style="fill:rgb(0%,0%,0%);fill-opacity:0.101961;stroke:none;"/>
+  </g>
+</mask>
+<image id="image6" width="9" height="9" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAJCAYAAADgkQYQAAAABmJLR0QA/wD/AP+gvaeTAAAAeklEQVQYlY3QsQoCQQyE4W/dFQTRQlsF4d7B2vd/Da8VRRv1XM8m4mEhpkmG/IGZJJ9Kg97H3A8XIxRMkFFxxQPPHOAYSzTYYI4OtyE0DWCHLRY44oR7CSjH9SpgoTNSCXMVZ7QBtKEr+vTlaY0ZLtjjgO6vdG/o559eaUMfCMRK6YkAAAAASUVORK5CYII="/>
+<clipPath id="clip2">
+  <rect x="0" y="0" width="64" height="64"/>
+</clipPath>
+<g id="surface10" clip-path="url(#clip2)">
+<use xlink:href="#image6" transform="matrix(2,0,0,2,0,10)"/>
+</g>
 </defs>
-<g id="surface1">
+<g id="surface2">
 <path style=" stroke:none;fill-rule:nonzero;fill:url(#linear0);" d="M 0 52 L 64 52 L 64 53 C 64 54.65625 62.65625 56 61 56 L 3 56 C 1.34375 56 0 54.65625 0 53 Z M 0 52 "/>
-<path style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:1;" d="M 45.09375 52.5 L 46.90625 52.5 C 47.234375 52.5 47.5 52.765625 47.5 53.09375 L 47.5 54.90625 C 47.5 55.234375 47.234375 55.5 46.90625 55.5 L 45.09375 55.5 C 44.765625 55.5 44.5 55.234375 44.5 54.90625 L 44.5 53.09375 C 44.5 52.765625 44.765625 52.5 45.09375 52.5 Z M 45.09375 52.5 "/>
-<path style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:1;" d="M 53.09375 52.5 L 54.90625 52.5 C 55.234375 52.5 55.5 52.765625 55.5 53.09375 L 55.5 54.90625 C 55.5 55.234375 55.234375 55.5 54.90625 55.5 L 53.09375 55.5 C 52.765625 55.5 52.5 55.234375 52.5 54.90625 L 52.5 53.09375 C 52.5 52.765625 52.765625 52.5 53.09375 52.5 Z M 53.09375 52.5 "/>
 <path style=" stroke:none;fill-rule:nonzero;fill:url(#linear1);" d="M 3 8 L 61 8 C 62.65625 8 64 9.34375 64 11 L 64 52 L 0 52 L 0 11 C 0 9.34375 1.34375 8 3 8 Z M 3 8 "/>
+<use xlink:href="#surface7" mask="url(#mask0)"/>
 <path style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:1;" d="M 7 24 L 11 24 C 11.550781 24 12 24.449219 12 25 L 12 29 C 12 29.550781 11.550781 30 11 30 L 7 30 C 6.449219 30 6 29.550781 6 29 L 6 25 C 6 24.449219 6.449219 24 7 24 Z M 7 24 "/>
+<use xlink:href="#surface10" mask="url(#mask1)"/>
 <path style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:1;" d="M 7 14 L 11 14 C 11.550781 14 12 14.449219 12 15 L 12 19 C 12 19.550781 11.550781 20 11 20 L 7 20 C 6.449219 20 6 19.550781 6 19 L 6 15 C 6 14.449219 6.449219 14 7 14 Z M 7 14 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:1;" d="M 55 54 C 55 54.550781 54.550781 55 54 55 C 53.449219 55 53 54.550781 53 54 C 53 53.449219 53.449219 53 54 53 C 54.550781 53 55 53.449219 55 54 Z M 55 54 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:1;" d="M 59 54 C 59 54.550781 58.550781 55 58 55 C 57.449219 55 57 54.550781 57 54 C 57 53.449219 57.449219 53 58 53 C 58.550781 53 59 53.449219 59 54 Z M 59 54 "/>
 </g>
 </svg>

--- a/src/apps/scalable/desktop.svg
+++ b/src/apps/scalable/desktop.svg
@@ -1,52 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="64" height="64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
- <metadata>
-  <rdf:RDF>
-   <cc:Work rdf:about="">
-    <dc:format>image/svg+xml</dc:format>
-    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-   </cc:Work>
-  </rdf:RDF>
- </metadata>
- <defs>
-  <linearGradient id="b" x1="399.57" x2="399.57" y1="545.8" y2="517.8" gradientTransform="matrix(2.1429 0 0 2.1429 -826.36 -1107.5)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#3889e9" offset="0"/>
-   <stop stop-color="#5ea5fb" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient873" x1="-45.602" x2="-33.697" y1="-2.1742" y2="6.0465" gradientTransform="matrix(3.7796 0 0 3.7796 200.68 -37.364)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#585858" offset="0"/>
-   <stop stop-color="#141414" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient16180" x1="38.817" x2="76.678" y1="-39.532" y2="-3.3168" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#2eadea" offset="0"/>
-   <stop stop-color="#a084e3" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient24430" x1="58.447" x2="76.678" y1="-33.84" y2="-3.3168" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#0475d1" offset="0"/>
-   <stop stop-color="#3b509e" offset="1"/>
-  </linearGradient>
- </defs>
- <circle cx="32.02" cy="32.044" r="0" fill="url(#b)" stroke-width="1.5715"/>
- <circle cx="-1019.3" cy="-1202" r="0" fill="#5e4aa6"/>
- <g transform="matrix(.93844 0 0 .89815 -1.0564 48.981)">
-  <g transform="matrix(1.0655 0 0 .83503 -14.661 7.1279)">
-   <rect x="16.818" y="-61.178" width="60.001" height="60.001" ry="3" fill="url(#linearGradient873)" stroke-width="3.7796"/>
-   <path d="m58.447-33.84c-1.446 0-2.892 0.55411-4 1.6621l-31 31h50.373c1.662 0 3-1.338 3-3v-13.627l-14.373-14.373c-1.108-1.108-2.554-1.6621-4-1.6621z" fill="url(#linearGradient24430)"/>
-   <path d="m38.817-39.532c-1.0181 0-2.0363 0.38982-2.8164 1.1699l-19.184 19.184v15c0 1.662 1.338 3 3 3h54c1.3602 0 2.491-0.90222 2.8613-2.1387l-35.045-35.045c-0.7801-0.7801-1.7983-1.1699-2.8164-1.1699z" fill="url(#linearGradient16180)"/>
-  </g>
- </g>
- <g transform="translate(.5 -.83333)" fill="#fff">
-  <g transform="translate(-121 .33333)">
-   <rect x="126" y="13" width="7" height="7" ry="1"/>
-   <rect x="126" y="23.667" width="7" height="7" ry="1"/>
-   <rect x="126" y="34.333" width="7" height="7" ry="1"/>
-   <rect x="126" y="45" width="7" height="7" ry="1"/>
-  </g>
-  <g transform="translate(-75 .33333)">
-   <rect x="126" y="13" width="7" height="7" ry="1"/>
-   <rect x="126" y="23.667" width="7" height="7" ry="1"/>
-   <rect x="126" y="34.333" width="7" height="7" ry="1"/>
-   <rect x="126" y="45" width="7" height="7" ry="1"/>
-  </g>
- </g>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="64" height="64" viewBox="0 0 64 64" version="1.1">
+<defs>
+<linearGradient id="linear0" gradientUnits="userSpaceOnUse" x1="0" y1="27" x2="32" y2="27" gradientTransform="matrix(2,0,0,2,0,0)">
+<stop offset="0" style="stop-color:rgb(5.882353%,31.372549%,40.392157%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(1.176471%,21.176471%,36.862745%);stop-opacity:1;"/>
+</linearGradient>
+<linearGradient id="linear1" gradientUnits="userSpaceOnUse" x1="7.2736" y1="0.4343" x2="24.5255" y2="30.3154" gradientTransform="matrix(2,0,0,2,0,0)">
+<stop offset="0" style="stop-color:rgb(25.882353%,89.019608%,90.588235%);stop-opacity:1;"/>
+<stop offset="1" style="stop-color:rgb(3.529412%,43.529412%,74.509804%);stop-opacity:1;"/>
+</linearGradient>
+</defs>
+<g id="surface1">
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear0);" d="M 0 52 L 64 52 L 64 53 C 64 54.65625 62.65625 56 61 56 L 3 56 C 1.34375 56 0 54.65625 0 53 Z M 0 52 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:1;" d="M 45.09375 52.5 L 46.90625 52.5 C 47.234375 52.5 47.5 52.765625 47.5 53.09375 L 47.5 54.90625 C 47.5 55.234375 47.234375 55.5 46.90625 55.5 L 45.09375 55.5 C 44.765625 55.5 44.5 55.234375 44.5 54.90625 L 44.5 53.09375 C 44.5 52.765625 44.765625 52.5 45.09375 52.5 Z M 45.09375 52.5 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:1;" d="M 53.09375 52.5 L 54.90625 52.5 C 55.234375 52.5 55.5 52.765625 55.5 53.09375 L 55.5 54.90625 C 55.5 55.234375 55.234375 55.5 54.90625 55.5 L 53.09375 55.5 C 52.765625 55.5 52.5 55.234375 52.5 54.90625 L 52.5 53.09375 C 52.5 52.765625 52.765625 52.5 53.09375 52.5 Z M 53.09375 52.5 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:url(#linear1);" d="M 3 8 L 61 8 C 62.65625 8 64 9.34375 64 11 L 64 52 L 0 52 L 0 11 C 0 9.34375 1.34375 8 3 8 Z M 3 8 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:1;" d="M 7 24 L 11 24 C 11.550781 24 12 24.449219 12 25 L 12 29 C 12 29.550781 11.550781 30 11 30 L 7 30 C 6.449219 30 6 29.550781 6 29 L 6 25 C 6 24.449219 6.449219 24 7 24 Z M 7 24 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:1;" d="M 7 14 L 11 14 C 11.550781 14 12 14.449219 12 15 L 12 19 C 12 19.550781 11.550781 20 11 20 L 7 20 C 6.449219 20 6 19.550781 6 19 L 6 15 C 6 14.449219 6.449219 14 7 14 Z M 7 14 "/>
+</g>
 </svg>


### PR DESCRIPTION
![desktop](https://user-images.githubusercontent.com/31783838/134805644-9168ff9e-a84a-4d1a-b089-2ede759810b1.png)
![PaintDotNet_WTqMntsJ9S](https://user-images.githubusercontent.com/31783838/134805665-ad7152cd-d360-4e34-9af5-84efc1a436cb.png)

Original Windows 11 icon:
![32x32](https://user-images.githubusercontent.com/31783838/134805656-2b0da8d9-f22e-486d-a215-1b08414297a6.png)

Current icon:
![desktop (1)](https://user-images.githubusercontent.com/31783838/134805702-a63337f6-6641-44fd-9fa3-b5aa00fb4ef0.png)
